### PR TITLE
Optional goody: Convert class components to functional components. 

### DIFF
--- a/client/src/Login.js
+++ b/client/src/Login.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Redirect, useHistory } from "react-router-dom";
-import { connect } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import {
   Grid,
   Box,
@@ -13,14 +13,15 @@ import { login } from "./store/utils/thunkCreators";
 
 const Login = (props) => {
   const history = useHistory();
-  const { user, login } = props;
+  const user = useSelector(state => state.user);
+  const dispatch = useDispatch();
 
   const handleLogin = async (event) => {
     event.preventDefault();
     const username = event.target.username.value;
     const password = event.target.password.value;
 
-    await login({ username, password });
+    await dispatch(login({ username, password }));
   };
 
   if (user.id) {
@@ -28,7 +29,7 @@ const Login = (props) => {
   }
 
   return (
-    <Grid container justify="center">
+    <Grid container justifyContent="center">
       <Box>
         <Grid container item>
           <Typography>Need to register?</Typography>
@@ -66,18 +67,4 @@ const Login = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    user: state.user,
-  };
-};
-
-const mapDispatchToProps = (dispatch) => {
-  return {
-    login: (credentials) => {
-      dispatch(login(credentials));
-    },
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(Login);
+export default Login;

--- a/client/src/Signup.js
+++ b/client/src/Signup.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Redirect, useHistory } from "react-router-dom";
-import { connect } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import {
   Grid,
   Box,
@@ -12,10 +12,11 @@ import {
 } from "@material-ui/core";
 import { register } from "./store/utils/thunkCreators";
 
-const Login = (props) => {
+const SignUp = () => {
   const history = useHistory();
-  const { user, register } = props;
   const [formErrorMessage, setFormErrorMessage] = useState({});
+  const user = useSelector(state => state.user);
+  const dispatch = useDispatch();
 
   const handleRegister = async (event) => {
     event.preventDefault();
@@ -29,7 +30,7 @@ const Login = (props) => {
       return;
     }
 
-    await register({ username, email, password });
+    await dispatch(register({ username, email, password }));
   };
 
   if (user.id) {
@@ -37,7 +38,7 @@ const Login = (props) => {
   }
 
   return (
-    <Grid container justify="center">
+    <Grid container justifyContent="center">
       <Box>
         <Grid container item>
           <Typography>Need to log in?</Typography>
@@ -107,18 +108,4 @@ const Login = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    user: state.user,
-  };
-};
-
-const mapDispatchToProps = (dispatch) => {
-  return {
-    register: (credentials) => {
-      dispatch(register(credentials));
-    },
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(Login);
+export default SignUp;

--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -2,7 +2,7 @@ import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Box } from "@material-ui/core";
 import { Input, Header, Messages } from "./index";
-import { connect } from "react-redux";
+import { useSelector } from "react-redux";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -22,8 +22,8 @@ const useStyles = makeStyles(() => ({
 
 const ActiveChat = (props) => {
   const classes = useStyles();
-  const { user } = props;
-  const conversation = props.conversation || {};
+  const user = useSelector(state => state.user);
+  const conversation = useSelector(state => getConversation(state)) || {};
 
   return (
     <Box className={classes.root}>
@@ -53,15 +53,10 @@ const ActiveChat = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    user: state.user,
-    conversation:
-      state.conversations &&
-      state.conversations.find(
-        (conversation) => conversation.otherUser.username === state.activeConversation
-      )
-  };
-};
+const getConversation = (state) => {
+  return state.conversations && state.conversations.find(
+    (conversation) => conversation.otherUser.username === state.activeConversation
+  )
+}
 
-export default connect(mapStateToProps, null)(ActiveChat);
+export default ActiveChat;

--- a/client/src/components/ActiveChat/Header.js
+++ b/client/src/components/ActiveChat/Header.js
@@ -3,7 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Box, Typography } from "@material-ui/core";
 import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     display: "flex",
     alignItems: "center",

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -4,16 +4,16 @@ import {  useDispatch, useSelector } from "react-redux";
 import { postMessage,readMessages } from "../../store/utils/thunkCreators";
 import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     justifySelf: "flex-end",
-    marginTop: 15,
+    marginTop: theme.spacing(1),
   },
   input: {
     height: 70,
     backgroundColor: "#F4F6FA",
     borderRadius: 8,
-    marginBottom: 20,
+    marginBottom: theme.spacing(1),
   },
 }));
 

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -1,11 +1,10 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import { FormControl, FilledInput } from "@material-ui/core";
-import { withStyles } from "@material-ui/core/styles";
-import { connect } from "react-redux";
-import { postMessage } from "../../store/utils/thunkCreators";
-import { readMessages } from "../../store/utils/thunkCreators";
+import {  useDispatch, useSelector } from "react-redux";
+import { postMessage,readMessages } from "../../store/utils/thunkCreators";
+import { makeStyles } from "@material-ui/core/styles";
 
-const styles = {
+const useStyles = makeStyles((theme) => ({
   root: {
     justifySelf: "flex-end",
     marginTop: 15,
@@ -16,83 +15,51 @@ const styles = {
     borderRadius: 8,
     marginBottom: 20,
   },
-};
+}));
 
-class Input extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      text: "",
-    };
+
+const Input = (props) => {
+  const classes = useStyles();
+  const [text, setText] = useState("");
+  const user = useSelector(state => state.user);
+  const dispatch = useDispatch();
+  const handleChange = (event) => {
+    setText(event.target.value);
   }
-
-  handleChange = (event) => {
-    this.setState({
-      text: event.target.value,
-    });
-  };
-
-  handleFocus = async (event) => {
+  const handleFocus = async (event) => {
     event.preventDefault();
-    if (this.props.unreadMessagesCount > 0){
-      await this.props.readMessages(this.props.conversationId);
+    if (props.unreadMessagesCount > 0){
+      await dispatch(readMessages(props.conversationId));
     }
   }
-
-  handleSubmit = async (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
     // add sender user info if posting to a brand new convo, so that the other user will have access to username, profile pic, etc.
     const reqBody = {
       text: event.target.text.value,
-      recipientId: this.props.otherUser.id,
-      conversationId: this.props.conversationId,
-      sender: this.props.conversationId ? null : this.props.user,
+      recipientId: props.otherUser.id,
+      conversationId: props.conversationId,
+      sender: props.conversationId ? null : user,
     };
-    await this.props.postMessage(reqBody);
-    this.setState({
-      text: "",
-    });
-  };
-
-  render() {
-    const { classes } = this.props;
-    return (
-      <form className={classes.root} onSubmit={this.handleSubmit}>
-        <FormControl fullWidth hiddenLabel>
-          <FilledInput
-            classes={{ root: classes.input }}
-            disableUnderline
-            placeholder="Type something..."
-            value={this.state.text}
-            name="text"
-            onChange={this.handleChange}
-            onFocus={this.handleFocus}
-          />
-        </FormControl>
-      </form>
-    );
+    await dispatch(postMessage(reqBody));
+    setText("");
   }
+  return (
+    <form className={classes.root} onSubmit={handleSubmit}>
+      <FormControl fullWidth hiddenLabel>
+        <FilledInput
+          classes={{ root: classes.input }}
+          disableUnderline
+          placeholder="Type something..."
+          value={text}
+          name="text"
+          onChange={handleChange}
+          onFocus={handleFocus}
+        />
+      </FormControl>
+    </form>
+  );
+
 }
 
-const mapStateToProps = (state) => {
-  return {
-    user: state.user,
-    conversations: state.conversations,
-  };
-};
-
-const mapDispatchToProps = (dispatch) => {
-  return {
-    postMessage: (message) => {
-      dispatch(postMessage(message));
-    },
-    readMessages: (id) => {
-      dispatch(readMessages(id));
-    },
-  };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withStyles(styles)(Input));
+export default Input;

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -4,7 +4,7 @@ import {  useDispatch, useSelector } from "react-redux";
 import { postMessage,readMessages } from "../../store/utils/thunkCreators";
 import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     justifySelf: "flex-end",
     marginTop: 15,

--- a/client/src/components/ActiveChat/OtherUserBubble.js
+++ b/client/src/components/ActiveChat/OtherUserBubble.js
@@ -2,7 +2,7 @@ import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Box, Typography, Avatar } from "@material-ui/core";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     display: "flex"
   },
@@ -14,7 +14,7 @@ const useStyles = makeStyles(() => ({
   },
   usernameDate: {
     fontSize: 11,
-    color: "#BECCE2",
+    color: theme.palette.info.main,
     fontWeight: "bold",
     marginBottom: 5
   },

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -2,7 +2,7 @@ import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Box, Typography,Avatar } from "@material-ui/core";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     display: "flex",
     flexDirection: "column",
@@ -10,7 +10,7 @@ const useStyles = makeStyles(() => ({
   },
   date: {
     fontSize: 11,
-    color: "#BECCE2",
+    color: theme.palette.info.main,
     fontWeight: "bold",
     marginBottom: 5
   },

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,86 +1,54 @@
-import React, { Component } from "react";
-import { withStyles } from "@material-ui/core/styles";
+import React, {useRef, useEffect,useState } from "react";
 import { Redirect } from "react-router-dom";
-import { connect } from "react-redux";
+import { useSelector,useDispatch } from "react-redux";
 import { Grid, CssBaseline, Button } from "@material-ui/core";
 import { SidebarContainer } from "./Sidebar";
 import { ActiveChat } from "./ActiveChat";
 import { logout, fetchConversations } from "../store/utils/thunkCreators";
 import { clearOnLogout } from "../store/index";
+import { makeStyles } from "@material-ui/core/styles";
 
-const styles = {
+const useStyles = makeStyles((theme) =>({
   root: {
     height: "97vh",
   },
-};
+}));
 
-class Home extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isLoggedIn: false,
-    };
-  }
+const Home = () => {
+  const classes = useStyles();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const user = useSelector(state => state.user);
+  const dispatch = useDispatch();
+  const userId = useRef(user.id);
 
-  componentDidUpdate(prevProps) {
-    if (this.props.user.id !== prevProps.user.id) {
-      this.setState({
-        isLoggedIn: true,
-      });
+  useEffect(() => {
+    if (userId.current !== userId) {
+      setIsLoggedIn(true);
     }
-  }
+    dispatch(fetchConversations());
+  },[dispatch]);
 
-  componentDidMount() {
-    this.props.fetchConversations();
+  const handleLogout = async () => {
+    dispatch(logout(user.id));
+    dispatch(clearOnLogout());
   }
-
-  handleLogout = async () => {
-    await this.props.logout(this.props.user.id);
-  };
-
-  render() {
-    const { classes } = this.props;
-    if (!this.props.user.id) {
-      // If we were previously logged in, redirect to login instead of register
-      if (this.state.isLoggedIn) return <Redirect to="/login" />;
-      return <Redirect to="/register" />;
-    }
-    return (
-      <>
-        {/* logout button will eventually be in a dropdown next to username */}
-        <Button className={classes.logout} onClick={this.handleLogout}>
-          Logout
-        </Button>
-        <Grid container component="main" className={classes.root}>
-          <CssBaseline />
-          <SidebarContainer />
-          <ActiveChat />
-        </Grid>
-      </>
-    );
+  if (!user.id){
+    if (isLoggedIn) return <Redirect to="/login" />;
+    return <Redirect to="/register" />;
   }
+  return (
+    <>
+      {/* logout button will eventually be in a dropdown next to username */}
+      <Button className={classes.logout} onClick={handleLogout}>
+        Logout
+      </Button>
+      <Grid container component="main" className={classes.root}>
+        <CssBaseline />
+        <SidebarContainer />
+        <ActiveChat />
+      </Grid>
+    </>
+  );
 }
 
-const mapStateToProps = (state) => {
-  return {
-    user: state.user,
-    conversations: state.conversations,
-  };
-};
-
-const mapDispatchToProps = (dispatch) => {
-  return {
-    logout: (id) => {
-      dispatch(logout(id));
-      dispatch(clearOnLogout());
-    },
-    fetchConversations: () => {
-      dispatch(fetchConversations());
-    },
-  };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withStyles(styles)(Home));
+export default Home;

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect,useState } from "react";
+import React, { useEffect,useState } from "react";
 import { Redirect } from "react-router-dom";
 import { useSelector,useDispatch } from "react-redux";
 import { Grid, CssBaseline, Button } from "@material-ui/core";
@@ -8,7 +8,7 @@ import { logout, fetchConversations } from "../store/utils/thunkCreators";
 import { clearOnLogout } from "../store/index";
 import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles((theme) =>({
+const useStyles = makeStyles(() =>({
   root: {
     height: "97vh",
   },
@@ -19,12 +19,14 @@ const Home = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const user = useSelector(state => state.user);
   const dispatch = useDispatch();
-  const userId = useRef(user.id);
 
-  useEffect(() => {
-    if (userId.current !== userId) {
+  useEffect(() =>{
+    if (user.id){
       setIsLoggedIn(true);
     }
+  },[user])
+
+  useEffect(() => {
     dispatch(fetchConversations());
   },[dispatch]);
 

--- a/client/src/components/Sidebar/BadgeAvatar.js
+++ b/client/src/components/Sidebar/BadgeAvatar.js
@@ -33,7 +33,7 @@ const UserAvatar = (props) => {
         classes={{ badge: `${classes.badge} ${online && classes.online}` }}
         variant="dot"
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
-        overlap="circle">
+        overlap="circular">
         <Avatar alt={username} src={photoUrl} className={classes.profilePic}></Avatar>
       </Badge>
     </Box>

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -1,12 +1,12 @@
-import React, { Component } from "react";
+import React from "react";
 import { Box, Badge } from "@material-ui/core";
 import { BadgeAvatar, ChatContent } from "../Sidebar";
-import { withStyles } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
 import { setActiveChat } from "../../store/activeConversation";
 import { readMessages } from "../../store/utils/thunkCreators";
-import { connect } from "react-redux";
+import { useDispatch } from "react-redux";
 
-const styles = {
+const useStyles = makeStyles((theme) => ({
   root: {
     borderRadius: 8,
     height: 80,
@@ -21,23 +21,25 @@ const styles = {
   badge: {
     marginRight: 20,
   }
-};
 
-class Chat extends Component {
-  handleClick = async (conversation) => {
+})); 
+
+const Chat = (props) =>{
+  const classes = useStyles();
+  const dispatch = useDispatch()
+  const otherUser = props.conversation.otherUser;
+  const {unreadMessagesCount} = props.conversation;
+  
+
+  const handleClick = async (conversation) => {
     if (conversation.unreadMessagesCount > 0){
-      await this.props.readMessages(conversation.id);
+      await dispatch(readMessages(conversation.id));
     }
-    await this.props.setActiveChat(conversation.otherUser.username);
-  };
-
-  render() {
-    const { classes } = this.props;
-    const otherUser = this.props.conversation.otherUser;
-    const {unreadMessagesCount} = this.props.conversation;
+    await dispatch(setActiveChat(conversation.otherUser.username));
+  }
     return (
       <Box
-        onClick={() => this.handleClick(this.props.conversation)}
+        onClick={() => handleClick(props.conversation)}
         className={classes.root}
       >
         <BadgeAvatar
@@ -46,7 +48,7 @@ class Chat extends Component {
           online={otherUser.online}
           sidebar={true}
         />
-        <ChatContent conversation={this.props.conversation} />
+        <ChatContent conversation={props.conversation} />
         <Badge
           className={classes.badge}
           badgeContent={unreadMessagesCount} 
@@ -55,19 +57,6 @@ class Chat extends Component {
         </Badge>
       </Box>
     );
-  }
 }
 
-
-const mapDispatchToProps = (dispatch) => {
-  return {
-    setActiveChat: (id) => {
-      dispatch(setActiveChat(id));
-    },
-    readMessages: (id) => {
-      dispatch(readMessages(id));
-    },
-  };
-};
-
-export default connect(null, mapDispatchToProps)(withStyles(styles)(Chat));
+export default Chat;

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -6,7 +6,7 @@ import { setActiveChat } from "../../store/activeConversation";
 import { readMessages } from "../../store/utils/thunkCreators";
 import { useDispatch } from "react-redux";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     borderRadius: 8,
     height: 80,

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import { useSelector } from "react-redux";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -28,10 +29,9 @@ const useStyles = makeStyles((theme) => ({
 
 const ChatContent = (props) => {
   const classes = useStyles();
-
   const { conversation } = props;
   const { latestMessageText, otherUser } = conversation;
-  const lastMsg = conversation.messages[conversation.messages.length-1]
+  const user = useSelector(state => state.user);
   return (
     <Box className={classes.root}>
       <Box>
@@ -39,13 +39,19 @@ const ChatContent = (props) => {
           {otherUser.username}
         </Typography>
         <Typography 
-          className={!lastMsg?.readStatus ?classes.unreadPreviewText: classes.previewText }
+          className={unreadByCurrentUser(user,conversation)?classes.unreadPreviewText: classes.previewText }
         >
           {latestMessageText}
         </Typography>
       </Box>
     </Box>
   );
-};
-
+}
+const unreadByCurrentUser = (user, conversation) => {
+  const lastMsg = conversation.messages[conversation.messages.length-1];
+  if (lastMsg.senderId === user.id || lastMsg?.readStatus){
+    return false;
+  }
+  return true;
+}
 export default ChatContent;

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -3,7 +3,7 @@ import { Box, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { useSelector } from "react-redux";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     display: "flex",
     justifyContent: "space-between",

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -49,9 +49,6 @@ const ChatContent = (props) => {
 }
 const unreadByCurrentUser = (user, conversation) => {
   const lastMsg = conversation.messages[conversation.messages.length-1];
-  if (lastMsg.senderId === user.id || lastMsg?.readStatus){
-    return false;
-  }
-  return true;
+  return lastMsg.senderId !== user.id && !lastMsg?.readStatus
 }
 export default ChatContent;

--- a/client/src/components/Sidebar/CurrentUser.js
+++ b/client/src/components/Sidebar/CurrentUser.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { connect } from "react-redux";
+import { useSelector } from "react-redux";
 import { BadgeAvatar } from "./index";
 import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
 
@@ -34,8 +34,7 @@ const useStyles = makeStyles(() => ({
 
 const CurrentUser = (props) => {
   const classes = useStyles();
-
-  const user = props.user || {};
+  const user = useSelector(state => state.user) || {};
 
   return (
     <Box className={classes.root}>
@@ -48,10 +47,5 @@ const CurrentUser = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    user: state.user
-  };
-};
 
-export default connect(mapStateToProps)(CurrentUser);
+export default CurrentUser;

--- a/client/src/components/Sidebar/Search.js
+++ b/client/src/components/Sidebar/Search.js
@@ -4,7 +4,7 @@ import SearchIcon from "@material-ui/icons/Search";
 import { makeStyles } from "@material-ui/core/styles";
 
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   filledInput: {
     height: 50,
     background: "#E9EEF9",

--- a/client/src/components/Sidebar/Search.js
+++ b/client/src/components/Sidebar/Search.js
@@ -1,9 +1,10 @@
-import React, { Component } from "react";
+import React from "react";
 import { FormControl, FilledInput, InputAdornment } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
-import { withStyles } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
 
-const styles = {
+
+const useStyles = makeStyles((theme) => ({
   filledInput: {
     height: 50,
     background: "#E9EEF9",
@@ -22,34 +23,33 @@ const styles = {
       opacity: 1,
     },
   },
-};
 
-class Search extends Component {
-  handleSubmit = (event) => {
+}));
+
+const Search = (props) => {
+  const handleSubmit =(event) => {
     event.preventDefault();
-  };
-
-  render() {
-    const { classes } = this.props;
-    return (
-      <form onSubmit={this.handleSubmit}>
-        <FormControl fullWidth hiddenLabel>
-          <FilledInput
-            name="search"
-            onChange={this.props.handleChange}
-            classes={{ root: classes.filledInput, input: classes.input }}
-            disableUnderline
-            placeholder="Search"
-            startAdornment={
-              <InputAdornment position="start">
-                <SearchIcon />
-              </InputAdornment>
-            }
-          ></FilledInput>
-        </FormControl>
-      </form>
-    );
   }
+  const classes = useStyles();
+  return (
+    <form onSubmit={handleSubmit}>
+      <FormControl fullWidth hiddenLabel>
+        <FilledInput
+          name="search"
+          onChange={props.handleChange}
+          classes={{ root: classes.filledInput, input: classes.input }}
+          disableUnderline
+          placeholder="Search"
+          startAdornment={
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          }
+        ></FilledInput>
+      </FormControl>
+  </form>
+  );
 }
 
-export default withStyles(styles)(Search);
+
+export default Search;

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { connect } from "react-redux";
+import { useSelector } from "react-redux";
 import { Search, Chat, CurrentUser } from "./index.js";
 
 const useStyles = makeStyles(() => ({
@@ -21,7 +21,7 @@ const useStyles = makeStyles(() => ({
 
 const Sidebar = (props) => {
   const classes = useStyles();
-  const conversations = props.conversations || [];
+  const conversations = useSelector(state => state.conversations) || [];
   const { handleChange, searchTerm } = props;
 
   return (
@@ -38,10 +38,4 @@ const Sidebar = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    conversations: state.conversations
-  };
-};
-
-export default connect(mapStateToProps)(Sidebar);
+export default Sidebar;

--- a/client/src/components/Sidebar/SidebarContainer.js
+++ b/client/src/components/Sidebar/SidebarContainer.js
@@ -1,18 +1,17 @@
 import React, { useState } from "react";
-import { connect } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Sidebar } from "./index";
 import { searchUsers } from "../../store/utils/thunkCreators";
 import { clearSearchedUsers } from "../../store/conversations";
 
-const SidebarContainer = (props) => {
-  const { searchUsers, clearSearchedUsers } = props;
-
+const SidebarContainer = () => {
+  const dispatch = useDispatch();
   const [searchTerm, setSearchTerm] = useState("");
 
   const handleChange = async (event) => {
     if (event.target.value === "") {
       // clear searched convos from redux store
-      clearSearchedUsers();
+      dispatch(clearSearchedUsers());
       setSearchTerm("");
       return;
     }
@@ -21,22 +20,11 @@ const SidebarContainer = (props) => {
       setSearchTerm(event.target.value);
       return;
     }
-    await searchUsers(event.target.value);
+    await dispatch(searchUsers(event.target.value));
     setSearchTerm(event.target.value);
   };
 
   return <Sidebar handleChange={handleChange} searchTerm={searchTerm} />;
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    searchUsers: (username) => {
-      dispatch(searchUsers(username));
-    },
-    clearSearchedUsers: () => {
-      dispatch(clearSearchedUsers());
-    }
-  };
-};
-
-export default connect(null, mapDispatchToProps)(SidebarContainer);
+export default SidebarContainer;

--- a/client/src/components/SnackbarError.js
+++ b/client/src/components/SnackbarError.js
@@ -3,7 +3,7 @@ import { Button, Snackbar } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import Close from "@material-ui/icons/Close";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   snackbar: {
     backgroundColor: "red",
     fontWeight: "bold"

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -1,19 +1,20 @@
 import React, { useEffect, useState } from "react";
-import { Route, Switch, withRouter } from "react-router-dom";
-import { connect } from "react-redux";
+import { Route, Switch } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import { fetchUser } from "./store/utils/thunkCreators";
 import Signup from "./Signup.js";
 import Login from "./Login.js";
 import { Home, SnackbarError } from "./components";
 
-const Routes = (props) => {
-  const { user, fetchUser } = props;
+const Routes = () => {
   const [errorMessage, setErrorMessage] = useState("");
   const [snackBarOpen, setSnackBarOpen] = useState(false);
+  const user = useSelector(state => state.user);
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    fetchUser();
-  }, [fetchUser]);
+    dispatch(fetchUser());
+  }, [dispatch]);
 
   useEffect(() => {
     if (user.error) {
@@ -27,7 +28,7 @@ const Routes = (props) => {
     }
   }, [user.error]);
 
-  if (props.user.isFetchingUser) {
+  if (user.isFetchingUser) {
     return <div>Loading...</div>;
   }
 
@@ -46,7 +47,7 @@ const Routes = (props) => {
         <Route
           exact
           path="/"
-          render={(props) => (props.user?.id ? <Home /> : <Signup />)}
+          render={() => (user?.id ? <Home /> : <Signup />)}
         />
         <Route path="/home" component={Home} />
       </Switch>
@@ -54,18 +55,4 @@ const Routes = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    user: state.user,
-  };
-};
-
-const mapDispatchToProps = (dispatch) => {
-  return {
-    fetchUser() {
-      dispatch(fetchUser());
-    },
-  };
-};
-
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Routes));
+export default Routes;

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -1,6 +1,6 @@
-import { createMuiTheme } from "@material-ui/core";
+import { createTheme } from "@material-ui/core";
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
   typography: {
     fontFamily: "Open Sans, sans-serif",
     fontSize: 14,

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -19,6 +19,8 @@ export const theme = createTheme({
   },
   palette: {
     primary: { main: "#3A8DFF" },
-    secondary: { main: "#B0B0B0" }
-  }
+    secondary: { main: "#B0B0B0" },
+    info: {main: "#BECCE2"}
+  },
+  spacing: 20
 });


### PR DESCRIPTION
Converted all class components to functional components #4, and replaced all `connect` API to Hooks, such as `useSelector` and `useDispatch`. So the front-end codebase will be cleaner and easy to read than the one with `connect` API.  
* Updated material-ui components from deprecated ones to the newest ones.  
* Fixed bolding preview text bug that the sender was able to see a bolding preview text he sent.  
* Removed unused dependencies. 